### PR TITLE
split out swagger middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ typings/
 
 # next.js build output
 .next
+
+.vscode

--- a/app.js
+++ b/app.js
@@ -40,7 +40,8 @@ app.use("/bake", bakeRouter);
 
 
 // Default route
-app.get("/", swaggerUi.serve, swaggerUi.setup(YAML.parse(swaggerFile)));
+app.use("/", swaggerUi.serve);
+app.get("/", swaggerUi.setup(YAML.parse(swaggerFile)));
 
 
 // Error handling - place after all other middleware and routes


### PR DESCRIPTION
This resolves a bug where the swagger doc resources were not available.

#5 