### PR TITLE
optionally define outputType in request. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - lts/*
-cache: npm
-install: npm install
-script:
-  - npm test

--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -1,4 +1,4 @@
-import { OperationError } from "cyberchef/src/node/index.mjs";
+import { OperationError, DishError } from "cyberchef/src/node/index.mjs";
 
 
 /**
@@ -17,7 +17,11 @@ export default function errorHandler(err, req, res, next) {
         return next(err);
     }
 
-    if (err instanceof TypeError || err instanceof OperationError) {
+    if (
+        err instanceof TypeError ||
+        err instanceof OperationError ||
+        err instanceof DishError
+    ) {
         res.status(400).send(err.message).end();
     } else {
         res.status(500).send(err.stack).end();

--- a/routes/bake.js
+++ b/routes/bake.js
@@ -23,10 +23,11 @@ router.post("/", async function bakePost(req, res, next) {
             dish.get(req.body.outputType);
         }
 
-        res.status(200).send({
+        res.send({
             value: dish.value,
             type: Dish.enumLookup(dish.type),
         });
+
     } catch (e) {
         next(e);
     }

--- a/routes/bake.js
+++ b/routes/bake.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 const router = Router();
-import { bake } from "cyberchef/src/node/index.mjs";
+import { bake, Dish } from "cyberchef/src/node/index.mjs";
 
 /**
  * bakePost
@@ -16,7 +16,17 @@ router.post("/", async function bakePost(req, res, next) {
         }
 
         const dish = await bake(req.body.input, req.body.recipe);
-        res.send(dish.value);
+
+        // Attempt to translate to another type. Any translation errors
+        // propagate through to the errorHandler.
+        if (req.body.outputType) {
+            dish.get(req.body.outputType);
+        }
+
+        res.status(200).send({
+            value: dish.value,
+            type: Dish.enumLookup(dish.type),
+        });
     } catch (e) {
         next(e);
     }

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,9 +1,0 @@
-const express = require("express");
-const router = express.Router();
-
-/* GET users listing. */
-router.get("/", function(req, res, next) {
-    res.send("respond with a resource");
-});
-
-module.exports = router;

--- a/test/bake.js
+++ b/test/bake.js
@@ -47,7 +47,7 @@ describe("POST /bake", function() {
             .expect({
                 value: "00000000  68 65 6c 6c 6f                                   |hello|",
                 type: "string",
-             }, done);
+            }, done);
     });
 
     it("should parse the recipe if it is a valid operation name string", (done) => {
@@ -83,7 +83,7 @@ describe("POST /bake", function() {
             .expect({
                 value: "54:65:73:74:69:6e:67:2c:20:31:20:32:20:33",
                 type: "string",
-             }, done);
+            }, done);
     });
 
     it("should parse the recipe if it is an operation with no custom arguments", (done) => {
@@ -95,7 +95,7 @@ describe("POST /bake", function() {
             .expect({
                 value: "54 65 73 74 69 6e 67 2c 20 31 20 32 20 33",
                 type: "string",
-             }, done);
+            }, done);
     });
 
     it("should parse a recipe in the compact JSON format taken from the CyberChef website", (done) => {
@@ -107,7 +107,7 @@ describe("POST /bake", function() {
             .expect({
                 value: "begin_something_anananaaaaak_da_aaak_da_aaaaananaaaaaaan_da_aaaaaaanan_da_aaak_end_something",
                 type: "string",
-             }, done);
+            }, done);
     });
 
     it("should parse a recipe ib the clean JSON format taken from the CyberChef website", (done) => {
@@ -126,7 +126,7 @@ describe("POST /bake", function() {
             .expect({
                 value: "begin_something_anananaaaaak_da_aaak_da_aaaaananaaaaaaan_da_aaaaaaanan_da_aaak_end_something",
                 type: "string",
-             }, done);
+            }, done);
     });
 
     it("should return a useful error if we give an input/recipe combination that results in an OperationError", (done) => {
@@ -159,7 +159,7 @@ describe("POST /bake", function() {
             .expect({
                 value: [54, 57, 32, 55, 50, 32, 55, 50, 32, 54, 53, 32, 54, 55, 32, 55, 53, 32, 54, 99, 32, 54, 49, 32, 55, 50, 32, 50, 48, 32, 54, 49, 32, 54, 99, 32, 54, 51, 32, 54, 102, 32, 55, 54, 32, 54, 53],
                 type: "byteArray",
-             }, done);
+            }, done);
     });
 
     it("should return a json output as a number, if outputType is defined", (done) => {
@@ -175,20 +175,20 @@ describe("POST /bake", function() {
             .expect({
                 value: 3.893660689688185,
                 type: "number",
-             }, done);
+            }, done);
     });
 
     it("should return a useful error if returnType is given but has an invalid value", (done) => {
         request(app)
-        .post("/bake")
-        .set("Content-Type", "application/json")
-        .send({
-            input: "irregular alcove",
-            recipe: "to hex",
-            outputType: "some invalid type",
-        })
-        .expect(400)
-        .expect("Invalid data type string. No matching enum.", done);
+            .post("/bake")
+            .set("Content-Type", "application/json")
+            .send({
+                input: "irregular alcove",
+                recipe: "to hex",
+                outputType: "some invalid type",
+            })
+            .expect(400)
+            .expect("Invalid data type string. No matching enum.", done);
     });
 
 });

--- a/test/bake.js
+++ b/test/bake.js
@@ -32,7 +32,10 @@ describe("POST /bake", function() {
             .post("/bake")
             .send({input: "testing, one two three", recipe: []})
             .expect(200)
-            .expect("testing, one two three", done);
+            .expect({
+                value: "testing, one two three",
+                type: "string",
+            }, done);
     });
 
     it("should parse the recipe if it is a valid operation name", (done) => {
@@ -41,7 +44,10 @@ describe("POST /bake", function() {
             .set("Content-Type", "application/json")
             .send({input: "hello", recipe: "To Hexdump"})
             .expect(200)
-            .expect("00000000  68 65 6c 6c 6f                                   |hello|", done);
+            .expect({
+                value: "00000000  68 65 6c 6c 6f                                   |hello|",
+                type: "string",
+             }, done);
     });
 
     it("should parse the recipe if it is a valid operation name string", (done) => {
@@ -50,7 +56,10 @@ describe("POST /bake", function() {
             .set("Content-Type", "application/json")
             .send({input: "hello", recipe: "toHexdump"})
             .expect(200)
-            .expect("00000000  68 65 6c 6c 6f                                   |hello|", done);
+            .expect({
+                value: "00000000  68 65 6c 6c 6f                                   |hello|",
+                type: "string",
+            }, done);
     });
 
     it("should parse the recipe if it is an array of operation names", (done) => {
@@ -59,7 +68,10 @@ describe("POST /bake", function() {
             .set("Content-Type", "application/json")
             .send({input: "Testing, 1 2 3", recipe: ["to decimal", "MD5", "to braille"]})
             .expect(200)
-            .expect("⠲⠆⠙⠋⠲⠆⠶⠶⠖⠶⠖⠙⠋⠶⠉⠆⠃⠲⠂⠑⠲⠢⠲⠆⠲⠒⠑⠶⠲⠢⠋⠃", done);
+            .expect({
+                value: "⠲⠆⠙⠋⠲⠆⠶⠶⠖⠶⠖⠙⠋⠶⠉⠆⠃⠲⠂⠑⠲⠢⠲⠆⠲⠒⠑⠶⠲⠢⠋⠃",
+                type: "string",
+            }, done);
     });
 
     it("should parse the recipe if it is an operation with some custom arguments", (done) => {
@@ -68,7 +80,10 @@ describe("POST /bake", function() {
             .set("Content-Type", "application/json")
             .send({input: "Testing, 1 2 3", recipe: { op: "to hex", args: { delimiter: "Colon" }}})
             .expect(200)
-            .expect("54:65:73:74:69:6e:67:2c:20:31:20:32:20:33", done);
+            .expect({
+                value: "54:65:73:74:69:6e:67:2c:20:31:20:32:20:33",
+                type: "string",
+             }, done);
     });
 
     it("should parse the recipe if it is an operation with no custom arguments", (done) => {
@@ -77,7 +92,10 @@ describe("POST /bake", function() {
             .set("Content-Type", "application/json")
             .send({input: "Testing, 1 2 3", recipe: {op: "to hex" }})
             .expect(200)
-            .expect("54 65 73 74 69 6e 67 2c 20 31 20 32 20 33", done);
+            .expect({
+                value: "54 65 73 74 69 6e 67 2c 20 31 20 32 20 33",
+                type: "string",
+             }, done);
     });
 
     it("should parse a recipe in the compact JSON format taken from the CyberChef website", (done) => {
@@ -86,7 +104,10 @@ describe("POST /bake", function() {
             .set("Content-Type", "application/json")
             .send({input: "some input", recipe: [{"op": "To Morse Code", "args": ["Dash/Dot", "Backslash", "Comma"]}, {"op": "Hex to PEM", "args": ["SOMETHING"]}, {"op": "To Snake case", "args": [false]}]})
             .expect(200)
-            .expect("begin_something_anananaaaaak_da_aaak_da_aaaaananaaaaaaan_da_aaaaaaanan_da_aaak_end_something", done);
+            .expect({
+                value: "begin_something_anananaaaaak_da_aaak_da_aaaaananaaaaaaan_da_aaaaaaanan_da_aaak_end_something",
+                type: "string",
+             }, done);
     });
 
     it("should parse a recipe ib the clean JSON format taken from the CyberChef website", (done) => {
@@ -102,7 +123,10 @@ describe("POST /bake", function() {
                     "args": [false] }
             ]})
             .expect(200)
-            .expect("begin_something_anananaaaaak_da_aaak_da_aaaaananaaaaaaan_da_aaaaaaanan_da_aaak_end_something", done);
+            .expect({
+                value: "begin_something_anananaaaaak_da_aaak_da_aaaaananaaaaaaan_da_aaaaaaanan_da_aaak_end_something",
+                type: "string",
+             }, done);
     });
 
     it("should return a useful error if we give an input/recipe combination that results in an OperationError", (done) => {
@@ -120,6 +144,51 @@ describe("POST /bake", function() {
             })
             .expect(400)
             .expect("Invalid key length: 2 bytes\n\nThe following algorithms will be used based on the size of the key:\n  16 bytes = AES-128\n  24 bytes = AES-192\n  32 bytes = AES-256", done);
+    });
+
+    it("should return a string output as a byte array, if outputType is defined", (done) => {
+        request(app)
+            .post("/bake")
+            .set("Content-Type", "application/json")
+            .send({
+                input: "irregular alcove",
+                recipe: "to hex",
+                outputType: "byte array",
+            })
+            .expect(200)
+            .expect({
+                value: [54, 57, 32, 55, 50, 32, 55, 50, 32, 54, 53, 32, 54, 55, 32, 55, 53, 32, 54, 99, 32, 54, 49, 32, 55, 50, 32, 50, 48, 32, 54, 49, 32, 54, 99, 32, 54, 51, 32, 54, 102, 32, 55, 54, 32, 54, 53],
+                type: "byteArray",
+             }, done);
+    });
+
+    it("should return a json output as a number, if outputType is defined", (done) => {
+        request(app)
+            .post("/bake")
+            .set("Content-Type", "application/json")
+            .send({
+                input: "something oddly colourful",
+                recipe: "entropy",
+                outputType: "number",
+            })
+            .expect(200)
+            .expect({
+                value: 3.893660689688185,
+                type: "number",
+             }, done);
+    });
+
+    it("should return a useful error if returnType is given but has an invalid value", (done) => {
+        request(app)
+        .post("/bake")
+        .set("Content-Type", "application/json")
+        .send({
+            input: "irregular alcove",
+            recipe: "to hex",
+            outputType: "some invalid type",
+        })
+        .expect(400)
+        .expect("Invalid data type string. No matching enum.", done);
     });
 
 });


### PR DESCRIPTION
add the ability to optionally define an `outputType` property in the request body. This will instruct the application to attempt to translate the output to that type before returning it.

- If the outputType is invalid or the dish fails to translate it for some other reason, you will get a 400.
- on 200, the application now returns an object with `value` and `type` properties. This is so that the type is explicit and so that we can return numbers as numbers ([express send doesn't accept numbers](https://expressjs.com/en/api.html#res.send)) 

