### PR TITLE
Add /operations endpoint to list available operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A Docker image can be built, then run by doing the following:
 ## API overview
 > For full documentation of the API, you can find the swagger page hosted at the root url. See [Installing](#Installing) to run the application and browse the docs.
 
-Currently the server just has one endpoint: `/bake`. This endpoint accepts a POST request with the following body:
+The most important endpoint is `/bake`. This endpoint accepts a POST request with the following body:
 
 |Parameter|Type|Description|
 |---|---|---|
@@ -157,6 +157,52 @@ Response:
     // Be wary, type conversions do not always behave as expected.
     "value": 79,
     "type": "number"
+}
+```
+
+There is also a `/operations` endpoint. This endpoint accepts a GET request and responds with a JSON object listing the available operations on this server. Each operation name is one attribute, and its value is the description of the arguments it can take.
+
+#### Example: operation list
+Response:
+```javascript
+{
+   "FromBase64" : {
+      "alphabet" : {
+         "type" : "editableOption",
+         "options" : [
+            {
+               "name" : "Standard (RFC 4648): A-Za-z0-9+/=",
+               "value" : "A-Za-z0-9+/="
+            },
+            {
+               "name" : "URL safe (RFC 4648 §5): A-Za-z0-9-_",
+               "value" : "A-Za-z0-9-_"
+            },
+            [...]
+         ]
+      },
+      "removeNon-alphabetChars" : {
+         "type" : "boolean",
+         "value" : true
+      }
+   },
+   "ToBase64" : {
+      "alphabet" : {
+         "type" : "editableOption",
+         "options" : [
+            {
+               "name" : "Standard (RFC 4648): A-Za-z0-9+/=",
+               "value" : "A-Za-z0-9+/="
+            },
+            {
+               "name" : "URL safe (RFC 4648 §5): A-Za-z0-9-_",
+               "value" : "A-Za-z0-9-_"
+            },
+            [...]
+         ]
+      }
+   },
+   [...]
 }
 ```
 

--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ import errorHandler from "./lib/errorHandler.js";
 import helmet from "helmet";
 
 import bakeRouter from "./routes/bake";
+import operationsRouter from "./routes/operations";
 
 const app = express();
 app.disable("x-powered-by");
@@ -37,6 +38,7 @@ const swaggerFile = fs.readFileSync("./swagger.yml", "utf8");
 
 // Routes
 app.use("/bake", bakeRouter);
+app.use("/operations", operationsRouter);
 
 
 // Default route

--- a/routes/operations.js
+++ b/routes/operations.js
@@ -7,7 +7,7 @@ import { operations } from "cyberchef/src/node/index.mjs";
  */
 router.get("/", async (req, res, next) => {
     const ret = {};
-    for (let op of operations) {
+    for (const op of operations) {
         if (op.opName) ret[op.opName] = op.args;
     }
     res.send(ret);

--- a/routes/operations.js
+++ b/routes/operations.js
@@ -1,0 +1,16 @@
+import { Router } from "express";
+const router = Router();
+import { operations } from "cyberchef/src/node/index.mjs";
+
+/**
+ * operationsGet
+ */
+router.get("/", async (req, res, next) => {
+    const ret = {};
+    for (let op of operations) {
+        if (op.opName) ret[op.opName] = op.args;
+    }
+    res.send(ret);
+});
+
+export default router;

--- a/swagger.yml
+++ b/swagger.yml
@@ -6,6 +6,62 @@ info:
 
 
 paths:
+  /operations:
+    get:
+      summary: List available operations
+      description: >
+        Retrieve a list of all available operations on this server.
+        The return value is an object whose attributes are operation names,
+        and each attribute value is the description of the arguments
+        the argument takes.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                example: >
+                    {
+                       "FromBase64" : {
+                          "alphabet" : {
+                             "type" : "editableOption",
+                             "options" : [
+                                {
+                                   "name" : "Standard (RFC 4648): A-Za-z0-9+/=",
+                                   "value" : "A-Za-z0-9+/="
+                                },
+                                {
+                                   "name" : "URL safe (RFC 4648 §5): A-Za-z0-9-_",
+                                   "value" : "A-Za-z0-9-_"
+                                },
+                                [...]
+                             ]
+                          },
+                          "removeNon-alphabetChars" : {
+                             "type" : "boolean",
+                             "value" : true
+                          }
+                       },
+                       "ToBase64" : {
+                          "alphabet" : {
+                             "type" : "editableOption",
+                             "options" : [
+                                {
+                                   "name" : "Standard (RFC 4648): A-Za-z0-9+/=",
+                                   "value" : "A-Za-z0-9+/="
+                                },
+                                {
+                                   "name" : "URL safe (RFC 4648 §5): A-Za-z0-9-_",
+                                   "value" : "A-Za-z0-9-_"
+                                },
+                                [...]
+                             ]
+                          }
+                       },
+                       [...]
+                    }
+
   /bake:
     post:
       summary: Bakes a recipe


### PR DESCRIPTION
This is a straightforward change to add a `/operations` endpoint which
can be used to get a list of the available operations on the CyberChef
server. The returned object has an attribute for each operation name,
with the argument description as its value.

This change also documents this new endpoint in `README.md` and
`swagger.yml`.