### PR TITLE
Add /operations endpoint to list available operations v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ A Docker image can be built, then run by doing the following:
 ## API overview
 > For full documentation of the API, you can find the swagger page hosted at the root url. See [Installing](#Installing) to run the application and browse the docs.
 
-The server has two endpoints: `/bake` and `/magic`.
+The server has these endpoints:
+
+* [`/bake`](#user-content-bake)
+* [`/magic`](#user-content-magic)
+* [`/operations`](#user-content-operations)
 
 ### `/bake`
 
@@ -212,6 +216,54 @@ Response:
 }
 ```
 
+
+### `/operations`
+
+This endpoint accepts a GET request and responds with a JSON object listing the available operations on this server. Each operation name is one attribute, and its value is the description of the arguments it can take.
+
+#### Example: operation list
+Response:
+```javascript
+{
+   "FromBase64" : {
+      "alphabet" : {
+         "type" : "editableOption",
+         "options" : [
+            {
+               "name" : "Standard (RFC 4648): A-Za-z0-9+/=",
+               "value" : "A-Za-z0-9+/="
+            },
+            {
+               "name" : "URL safe (RFC 4648 §5): A-Za-z0-9-_",
+               "value" : "A-Za-z0-9-_"
+            },
+            [...]
+         ]
+      },
+      "removeNon-alphabetChars" : {
+         "type" : "boolean",
+         "value" : true
+      }
+   },
+   "ToBase64" : {
+      "alphabet" : {
+         "type" : "editableOption",
+         "options" : [
+            {
+               "name" : "Standard (RFC 4648): A-Za-z0-9+/=",
+               "value" : "A-Za-z0-9+/="
+            },
+            {
+               "name" : "URL safe (RFC 4648 §5): A-Za-z0-9-_",
+               "value" : "A-Za-z0-9-_"
+            },
+            [...]
+         ]
+      }
+   },
+   [...]
+}
+```
 
 ## Licencing
 

--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ import helmet from "helmet";
 
 import bakeRouter from "./routes/bake";
 import magicRouter from "./routes/magic";
+import operationsRouter from "./routes/operations";
 
 const app = express();
 app.disable("x-powered-by");
@@ -39,6 +40,7 @@ const swaggerFile = fs.readFileSync("./swagger.yml", "utf8");
 // Routes
 app.use("/bake", bakeRouter);
 app.use("/magic", magicRouter);
+app.use("/operations", operationsRouter);
 
 
 // Default route

--- a/routes/operations.js
+++ b/routes/operations.js
@@ -5,7 +5,7 @@ import { operations } from "cyberchef/src/node/index.mjs";
 /**
  * operationsGet
  */
-router.get("/", async (req, res, next) => {
+router.get("/", async function (req, res, next) {
     const ret = {};
     for (const op of operations) {
         if (op.opName) ret[op.opName] = op.args;

--- a/routes/operations.js
+++ b/routes/operations.js
@@ -7,7 +7,7 @@ import { operations } from "cyberchef/src/node/index.mjs";
  */
 router.get("/", async (req, res, next) => {
     const ret = {};
-    for (let op of operations) {
+    for (const op of operations) {
         if (op.opName) ret[op.opName] = op.args;
     }
     res.send(ret);

--- a/routes/operations.js
+++ b/routes/operations.js
@@ -1,0 +1,16 @@
+import { Router } from "express";
+const router = Router();
+import { operations } from "cyberchef/src/node/index.mjs";
+
+/**
+ * operationsGet
+ */
+router.get("/", async (req, res, next) => {
+    const ret = {};
+    for (let op of operations) {
+        if (op.opName) ret[op.opName] = op.args;
+    }
+    res.send(ret);
+});
+
+export default router;

--- a/swagger.yml
+++ b/swagger.yml
@@ -6,6 +6,42 @@ info:
 
 
 paths:
+  /operations:
+    get:
+      summary: List available operations
+      description: >
+        Retrieve a list of all available operations on this server.
+        The return value is an object whose attributes are operation names,
+        and each attribute value is the description of the arguments
+        the argument takes.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  FromBase64:
+                    alphabet:
+                      type: "editableOption"
+                      options:
+                        - name: "Standard (RFC 4648): A-Za-z0-9+/="
+                          value: "A-Za-z0-9+/="
+                        - name: "URL safe (RFC 4648 §5): A-Za-z0-9-_"
+                          value: "A-Za-z0-9-_"
+                    removeNon-alphabetChars:
+                      type: boolean
+                      value: true
+                  ToBase64:
+                    alphabet:
+                      type: "editableOption"
+                      options:
+                        - name: "Standard (RFC 4648): A-Za-z0-9+/="
+                          value: "A-Za-z0-9+/="
+                        - name: "URL safe (RFC 4648 §5): A-Za-z0-9-_"
+                          value: "A-Za-z0-9-_"
+
   /bake:
     post:
       summary: Bakes a recipe
@@ -189,4 +225,3 @@ components:
           items:
             type: Object
         useful: bool
- 

--- a/test/operations.js
+++ b/test/operations.js
@@ -1,0 +1,23 @@
+import assert from "assert";
+import request from "supertest";
+import app from "../app";
+
+describe("GET /operations", function() {
+    it("exists", (done) => {
+        request(app)
+            .get("/operations")
+            .expect(200, done);
+    });
+
+    it("contains some operations", (done) => {
+        request(app)
+            .get("/operations")
+            .expect(200)
+            .end(function(err, res) {
+                if(err) return done(err);
+                assert.notStrictEqual(res.body.ToBraille, undefined);
+                assert.notStrictEqual(res.body.ToBase, undefined);
+                done();
+            });
+    });
+});


### PR DESCRIPTION
Updated version of #17 that's based on the current master (as of submission). From there:

> This is a straightforward change to add a /operations endpoint which
can be used to get a list of the available operations on the CyberChef
server. The returned object has an attribute for each operation name,
with the argument description as its value.

This change also documents this new endpoint in `README.md` and `swagger.yml`, and also includes a test case.