### PR TITLE
Fix for npm not finding the path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL author "Wes Lambert, wlambertts@gmail.com"
 LABEL description="Dockerised version of Cyberchef server (https://github.com/gchq/CyberChef-server)"
 LABEL copyright "Crown Copyright 2020"
 LABEL license "Apache-2.0"
+WORKDIR /CyberChef-server
 COPY . /CyberChef-server
 RUN npm cache clean --force && \
          npm install /CyberChef-server


### PR DESCRIPTION
Fixes the following issue:

`npm ERR! could not detect node name from path or package`