### PR TITLE
add workdir to fix error during npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL author "Wes Lambert, wlambertts@gmail.com"
 LABEL description="Dockerised version of Cyberchef server (https://github.com/gchq/CyberChef-server)"
 LABEL copyright "Crown Copyright 2020"
 LABEL license "Apache-2.0"
+WORKDIR /CyberChef-server
 COPY . /CyberChef-server
 RUN npm cache clean --force && \
          npm install /CyberChef-server


### PR DESCRIPTION
Without workdir it'll generate the following error

```
Step 7/8 : RUN npm cache clean --force &&          npm install /CyberChef-server
 ---> Running in 14d85968a12c
npm WARN using --force Recommended protections disabled.
npm notice                                                                      
npm notice New minor version of npm available! 7.4.3 -> 7.5.1                   
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v7.5.1>          
npm notice Run `npm install -g npm@7.5.1` to update!                            
npm notice                                                                      
npm ERR! Tracker "idealTree" already exists
```