### PR TITLE
Added WORKDIR variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL description="Dockerised version of Cyberchef server (https://github.com/gc
 LABEL copyright "Crown Copyright 2020"
 LABEL license "Apache-2.0"
 COPY . /CyberChef-server
+WORKDIR /CyberChef-server
 RUN npm cache clean --force && \
          npm install /CyberChef-server
 ENTRYPOINT ["npm", "--prefix", "/CyberChef-server", "run", "prod"]


### PR DESCRIPTION
In order to circumvent the problem that from version 15 of nodejs, npm install is triggered from root directory, a WORKDIR variable has to be used as explained in https://stackoverflow.com/questions/57534295/npm-err-tracker-idealtree-already-exists-while-creating-the-docker-image-for.
This fixes the issue "npm ERR! Tracker "idealTree" already exists" that comes during build.