### PR TITLE
fix(routes): use date.toString

### DIFF
--- a/routes/health.js
+++ b/routes/health.js
@@ -8,7 +8,7 @@ router.get("/", async function healthGet(req, res, next) {
     const healthcheck = {
         uptime: process.uptime(),
         message: "OK",
-        timestamp: Date()
+        timestamp: new Date().toString()
     };
     try {
         res.send(healthcheck);


### PR DESCRIPTION
I've done a benchmark of `Date()` vs `new Date().toString()`and the later is a bit faster performance wise.

<img width="1436" alt="Screenshot 2024-08-04 at 13 51 59" src="https://github.com/user-attachments/assets/941c0ea5-a780-4534-80b3-d9a7aeb29b0e">
