### PR TITLE
Updating the node versions used to test commits ahead of v1.0.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Need to update versions of NodeJS used to test commits prior to V1 merge (support for v1 and v12 of Node is deprecated, so they need to be removed from the testing workflows prior to merging in the new changes to allow the merge to go through).