### PR TITLE
Adding Batch Baking feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,92 @@ Response:
 }
 ```
 
+### `/batch/bake`
+
+`/batch/bake` allows a user to POST multiple input values and a configuration for a CyberChef Recipe. The application will run each elemnt of the input through the recipe and return the results as an array of output objects.
+
+This endpoint accepts a POST request with the following body:
+
+|Parameter|Type|Description|
+|---|---|---|
+input|Array|The input data for the recipe. Currently accepts an array of Strings.
+recipe|String or Object or Array|One or more operations, with optional arguments. Uses default arguments if they're not defined here.
+outputType (optional)|String|The [Data Type](https://github.com/gchq/CyberChef/wiki/Adding-a-new-operation#data-types) that you would like the result of the bakes to be returned as. This will not work with `File` or `List<File>` at the moment.
+
+#### Example: one operation, default arguments
+```javascript
+{
+    "input": ["One", "two", "three", "four"],
+    "recipe": "to decimal"
+}
+```
+
+Response:
+```javascript
+[
+  {
+    "success": true,
+    "value": "79 110 101",
+    "type": "string"
+  },
+  {
+    "success": true,
+    "value": "116 119 111",
+    "type": "string"
+  },
+  {
+    "success": true,
+    "value": "116 104 114 101 101",
+    "type": "string"
+  },
+  {
+    "success": true,
+    "value": "102 111 117 114",
+    "type": "string"
+  }
+]
+
+```
+> For more information on how operation names are handled, see the [Node API docs](https://github.com/gchq/CyberChef/wiki/Node-API#operation-names)
+
+#### Example: one operation, non-default arguments by name
+```javascript
+{
+    "input": ["One", "two", "three", "four"],
+    "recipe": {
+        "op": "to decimal",
+        "args": {
+            "delimiter": "Colon"
+        }
+    }
+}
+```
+Response:
+```javascript
+[
+  {
+    "success": true,
+    "value": "79:110:101",
+    "type": "string"
+  },
+  {
+    "success": true,
+    "value": "116:119:111",
+    "type": "string"
+  },
+  {
+    "success": true,
+    "value": "116:104:114:101:101",
+    "type": "string"
+  },
+  {
+    "success": true,
+    "value": "102:111:117:114",
+    "type": "string"
+  }
+]
+```
+
 ### `/magic`
 
 [Find more information about what the Magic operation does here](https://github.com/gchq/CyberChef/wiki/Automatic-detection-of-encoded-data-using-CyberChef-Magic)

--- a/src/app.mjs
+++ b/src/app.mjs
@@ -13,6 +13,7 @@ import helmet from "helmet";
 import bakeRouter from "./routes/bake.mjs";
 import magicRouter from "./routes/magic.mjs";
 import healthRouter from "./routes/health.mjs";
+import batchBakeRouter from "./routes/batchBake.mjs";
 
 const app = express();
 app.disable("x-powered-by");
@@ -45,6 +46,8 @@ const swaggerFile = fs.readFileSync("./swagger.yml", "utf8");
 app.use("/health", healthRouter);
 app.use("/bake", bakeRouter);
 app.use("/magic", magicRouter);
+// Batch routes
+app.use("/batch/bake", batchBakeRouter);
 
 
 // Default route

--- a/src/lib/errorHandler.mjs
+++ b/src/lib/errorHandler.mjs
@@ -24,6 +24,7 @@ export default function errorHandler(err, req, res, next) {
     ) {
         res.status(400).send(err.message).end();
     } else {
-        res.status(500).send(err.stack).end();
+        req.log.error(err.stack);
+        res.status(500).send("Internal Server Error").end();
     }
 }

--- a/src/routes/batchBake.mjs
+++ b/src/routes/batchBake.mjs
@@ -1,0 +1,61 @@
+import { Router } from "express";
+const router = Router();
+import { bake, Dish } from "cyberchef";
+
+/**
+ * batchBakePost
+ */
+router.post("/", async function batchBakePost(req, res, next) {
+    try {
+        if (!req.body.input || !Array.isArray(req.body.input)) {
+            throw new TypeError("'input' property of type 'Array' is required in request body");
+        }
+
+        if (req.body.input.length === 0) {
+            throw new TypeError("'input' array must be non-empty");
+        }
+
+        if (!req.body.recipe) {
+            throw new TypeError("'recipe' property is required in request body");
+        }
+
+        // Results are objects with a result param if the result of the bake on the data
+        // item was successful and and error param if not that contains the string exception
+        // Result also contains the type, in line with the single bake endpoint
+        const retArr = req.body.input.map((input) => {
+            try {
+                const dish = bake(input, req.body.recipe);
+                let retVal = dish.value;
+                // Attempt to translate to another type. Any translation errors
+                // propagate through to the errorHandler.
+                if (req.body.outputType) {
+                    retVal = dish.get(req.body.outputType);
+                }
+                return {
+                    success: true,
+                    value: retVal,
+                    type: Dish.enumLookup(dish.type),
+                };
+            } catch (err) {
+                // Chef uses TypeError to indicate a problem with recipes. Safe to assume that a bad recipe
+                // will be a showstopper for all data so use the global error handler to handle this.
+                if (err instanceof TypeError) {
+                    req.log.error("Bad recipe");
+                    // Rethrow to activate the outer try/catch and exit the handling of this request
+                    throw err;
+                }
+                return {
+                    success: false,
+                    error: err.message,
+                };
+            }
+        });
+
+        res.send(retArr);
+
+    } catch (e) {
+        next(e);
+    }
+});
+
+export default router;

--- a/src/test/batchBake.mjs
+++ b/src/test/batchBake.mjs
@@ -1,0 +1,282 @@
+import request from "supertest";
+import app from "../app.mjs";
+
+
+describe("GET /batch/bake", function() {
+    it("doesnt exist", function(done) {
+        request(app)
+            .get("/batch/bake")
+            .set("Accept", "application/json")
+            .expect(404, done);
+    });
+});
+
+describe("POST /batch/bake", function() {
+    it("should error helpfully if there's no `input` property in request body", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .send({})
+            .expect(400)
+            .expect("'input' property of type 'Array' is required in request body", done);
+    });
+
+    it("should error helpfully if there's no `recipe` property in request body", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .send({input: ["hello"]})
+            .expect(400)
+            .expect("'recipe' property is required in request body", done);
+    });
+
+    it("should error helpfully if the `input` property in request body is not an array", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .send({input: "hello"})
+            .expect(400)
+            .expect("'input' property of type 'Array' is required in request body", done);
+    });
+
+    it("should error helpfully if the `input` property in request body is an empty array", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .send({input: []})
+            .expect(400)
+            .expect("'input' array must be non-empty", done);
+    });
+
+    it("should respond with the input if the recipe is empty", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .send({input: ["testing, one two three"], recipe: []})
+            .expect(200)
+            .expect([{
+                value: "testing, one two three",
+                type: "string",
+                success: true,
+            }], done);
+    });
+
+    it("should parse the recipe if it is a valid operation name", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({input: ["hello"], recipe: "To Hexdump"})
+            .expect(200)
+            .expect([{
+                value: "00000000  68 65 6c 6c 6f                                   |hello|",
+                type: "string",
+                success: true,
+            }], done);
+    });
+
+    it("should parse the recipe if it is a valid operation name string", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({input: ["hello"], recipe: "toHexdump"})
+            .expect(200)
+            .expect([{
+                value: "00000000  68 65 6c 6c 6f                                   |hello|",
+                type: "string",
+                success: true,
+            }], done);
+    });
+
+    it("should run the recipe across all elements of the input array", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({input: ["Annie", "Jeff", "Abed", "Shirley", "Britta", "Troy"], recipe: {"op": "Swap case", "args": [] }})
+            .expect(200)
+            .expect([
+                {
+                    value: "aNNIE",
+                    type: "string",
+                    success: true,
+                },
+                {
+                    value: "jEFF",
+                    type: "string",
+                    success: true,
+                },
+                {
+                    value: "aBED",
+                    type: "string",
+                    success: true,
+                },
+                {
+                    value: "sHIRLEY",
+                    type: "string",
+                    success: true,
+                },
+                {
+                    value: "bRITTA",
+                    type: "string",
+                    success: true,
+                },
+                {
+                    value: "tROY",
+                    type: "string",
+                    success: true,
+                },
+            ], done);
+    });
+
+    it("should parse the recipe if it is an array of operation names", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({input: ["Testing, 1 2 3"], recipe: ["to decimal", "MD5", "to braille"]})
+            .expect(200)
+            .expect([{
+                value: "⠲⠆⠙⠋⠲⠆⠶⠶⠖⠶⠖⠙⠋⠶⠉⠆⠃⠲⠂⠑⠲⠢⠲⠆⠲⠒⠑⠶⠲⠢⠋⠃",
+                type: "string",
+                success: true,
+            }], done);
+    });
+
+    it("should parse the recipe if it is an operation with some custom arguments", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({input: ["Testing, 1 2 3"], recipe: { op: "to hex", args: { delimiter: "Colon" }}})
+            .expect(200)
+            .expect([{
+                value: "54:65:73:74:69:6e:67:2c:20:31:20:32:20:33",
+                type: "string",
+                success: true,
+            }], done);
+    });
+
+    it("should parse the recipe if it is an operation with no custom arguments", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({input: ["Testing, 1 2 3"], recipe: {op: "to hex" }})
+            .expect(200)
+            .expect([{
+                value: "54 65 73 74 69 6e 67 2c 20 31 20 32 20 33",
+                type: "string",
+                success: true
+            }], done);
+    });
+
+    it("should parse a recipe in the compact JSON format taken from the CyberChef website", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({input: ["some input"], recipe: [{"op": "To Morse Code", "args": ["Dash/Dot", "Backslash", "Comma"]}, {"op": "Hex to PEM", "args": ["SOMETHING"]}, {"op": "To Snake case", "args": [false]}]})
+            .expect(200)
+            .expect([{
+                value: "begin_something_anananaaaaak_da_aaak_da_aaaaananaaaaaaan_da_aaaaaaanan_da_aaak_end_something",
+                type: "string",
+                success: true
+            }], done);
+    });
+
+    it("should parse a recipe ib the clean JSON format taken from the CyberChef website", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({input: ["some input"], recipe: [
+                { "op": "To Morse Code",
+                    "args": ["Dash/Dot", "Backslash", "Comma"] },
+                { "op": "Hex to PEM",
+                    "args": ["SOMETHING"] },
+                { "op": "To Snake case",
+                    "args": [false] }
+            ]})
+            .expect(200)
+            .expect([{
+                value: "begin_something_anananaaaaak_da_aaak_da_aaaaananaaaaaaan_da_aaaaaaanan_da_aaak_end_something",
+                type: "string",
+                success: true
+            }], done);
+    });
+
+    it("should return a useful error if we give an input/recipe combination that results in an OperationError", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({
+                input: ["irrelevant"],
+                recipe: {
+                    op: "AES Encrypt",
+                    args: {
+                        key: "notsixteencharslong"
+                    }
+                }
+            })
+            .expect(200)
+            .expect([{
+                success: false,
+                error: "Invalid key length: 3 bytes\n\nThe following algorithms will be used based on the size of the key:\n  16 bytes = AES-128\n  24 bytes = AES-192\n  32 bytes = AES-256"
+            }], done);
+    });
+
+    it("should return a string output as a byte array, if outputType is defined", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({
+                input: ["irregular alcove"],
+                recipe: "to hex",
+                outputType: "byte array",
+            })
+            .expect(200)
+            .expect([{
+                value: [54, 57, 32, 55, 50, 32, 55, 50, 32, 54, 53, 32, 54, 55, 32, 55, 53, 32, 54, 99, 32, 54, 49, 32, 55, 50, 32, 50, 48, 32, 54, 49, 32, 54, 99, 32, 54, 51, 32, 54, 102, 32, 55, 54, 32, 54, 53],
+                type: "byteArray",
+                success: true,
+            }], done);
+    });
+
+    it("should return a json output as a number, if outputType is defined", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({
+                input: ["something oddly colourful"],
+                recipe: "entropy",
+                outputType: "number",
+            })
+            .expect(200)
+            .expect([{
+                value: 3.893660689688185,
+                type: "number",
+                success: true,
+            }], done);
+    });
+
+    it("should return a useful error if returnType is given but has an invalid value", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({
+                input: ["irregular alcove"],
+                recipe: "to hex",
+                outputType: "some invalid type",
+            })
+            .expect(200)
+            .expect([{
+                success: false,
+                error: "Invalid data type string. No matching enum."
+            }], done);
+    });
+
+    it("should not perform MAGIC via /batch/bake", (done) => {
+        request(app)
+            .post("/batch/bake")
+            .set("Content-Type", "application/json")
+            .send({
+                input: ["You're a wizard, Harry."],
+                recipe: [
+                    "To Hex",
+                    "Magic"
+                ]
+            })
+            .expect(400)
+            .expect("flowControl operations like Magic are not currently allowed in recipes for chef.bake in the Node API", done);
+    });
+
+});

--- a/swagger.yml
+++ b/swagger.yml
@@ -126,8 +126,8 @@ paths:
     post:
       summary: Bakes a batch of data with a recipe
       description: >
-        Bake a recipe defined in JSON over and array of input data. For an example JSON recipe, build a recipe on 
-        [CyberChef](https://gchq.github.io/CyberChef/) and click save. Select "clean JSON".
+        Bake a recipe defined in JSON over an array of input data. To obtain a JSON-formatted recipe, build a recipe on 
+        [CyberChef](https://gchq.github.io/CyberChef/) and click save. Select "clean JSON" and copy the output.
         
         Input data must be in the form of an array. All items will be baked individually 
         and an individual result object provided for each in the response
@@ -163,10 +163,10 @@ paths:
                 - type: "string"
                   value: "01001110"
                   success: true
-                - error: "Bad Recipe"
+                - error: "Spline reticulation exception"
                   success: false
         '400':
-          description: Bad request
+          description: Bad request, most often a syntactically invalid recipe
 
 components:
   schemas:

--- a/swagger.yml
+++ b/swagger.yml
@@ -122,7 +122,51 @@ paths:
                           - 123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz
                           - false
                     useful: false
+  /batch/bake:
+    post:
+      summary: Bakes a batch of data with a recipe
+      description: >
+        Bake a recipe defined in JSON over and array of input data. For an example JSON recipe, build a recipe on 
+        [CyberChef](https://gchq.github.io/CyberChef/) and click save. Select "clean JSON".
+        
+        Input data must be in the form of an array. All items will be baked individually 
+        and an individual result object provided for each in the response
 
+        The Recipe property in the payload is designed so that you only need to provide
+        arguments for operations if they are required, or you want to change them from the default.
+        For more information on accepted recipe formats, see the [bake section of the Node API docs](https://github.com/gchq/CyberChef/wiki/Node-API#bake)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/SingleOpBatchRecipe"
+                - $ref: "#/components/schemas/MultiOpBatchRecipe"
+            example:
+              input: ["some input", "some more input"]
+              recipe:
+                - op: toHex
+                - op: toBase64
+                - op: toBinary
+                  args:
+                    delimiter: "Comma"
+
+      responses:
+        '200':
+          description: Inputs were syntactically valid, individual bakes may or may not have succeeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchBakeResponse"
+              example:
+                - type: "string"
+                  value: "01001110"
+                  success: true
+                - error: "Bad Recipe"
+                  success: false
+        '400':
+          description: Bad request
 
 components:
   schemas:
@@ -147,6 +191,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Operation"
+
     Operation:
       type: object
       properties:
@@ -158,11 +203,64 @@ components:
             - $ref: "#/components/schemas/ArgObject"
       required:
         - op
+    
+    SingleOpBatchRecipe:
+      type: object
+      properties:
+        input:
+          type: object
+          example: "bake this"
+        recipe:
+          $ref: "#/components/schemas/Operation"
+          example:
+            op: "toHex"
+
+    MultiOpBatchRecipe:
+      type: object
+      properties:
+        input: 
+          type: string
+          example: "input for recipe"
+        recipe:
+          type: array
+          items:
+            $ref: "#/components/schemas/Operation"
 
     OperationArray:
       type: array
       items: 
         $ref: "#/components/schemas/Operation"
+
+    
+    InputArray:
+      type: array
+      items: 
+        type: string
+
+    BatchBakeResponse:
+      type: array
+      items:
+        oneOf:
+          - $ref: "#/components/schemas/SuccessfulBakeResult"
+          - $ref: "#/components/schemas/UnsuccessfulBakeResult"
+
+    SuccessfulBakeResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+        value:
+          type: string
+        type:
+          type: string
+
+    UnsuccessfulBakeResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+        error:
+          type: string    
       
     ArgArray:
       type: array

--- a/swagger.yml
+++ b/swagger.yml
@@ -2,13 +2,15 @@ openapi: 3.0.0
 info:
   title: CyberChef API
   description: A HTTP API that exposes some of CyberChef's functionality.
-  version: 0.0.10
+  version: 1.1.0
 
 
 paths:
   /health:
     get:
       summary: Server healthcheck
+      tags:
+        - Health
       description: >
         If the server is up, returns a 200 response and some basic info about uptime
 
@@ -37,6 +39,8 @@ paths:
   /bake:
     post:
       summary: Bakes a recipe
+      tags:
+        - Single Operations
       description: >
         Bake a recipe defined in JSON. For an example JSON recipe, build a recipe on 
         [CyberChef](https://gchq.github.io/CyberChef/) and click save. Select "clean JSON".
@@ -78,6 +82,8 @@ paths:
   /magic:
     post:
       summary: Performs magic on some input
+      tags:
+        - Single Operations
       description: >
         Take some input data and optional arguments for the [Magic operation](https://github.com/gchq/CyberChef/wiki/Automatic-detection-of-encoded-data-using-CyberChef-Magic) and return JSON of results of automatic encoding detection of the inputted data.
 
@@ -125,6 +131,8 @@ paths:
   /batch/bake:
     post:
       summary: Bakes a batch of data with a recipe
+      tags:
+        - Batch Operations
       description: >
         Bake a recipe defined in JSON over an array of input data. To obtain a JSON-formatted recipe, build a recipe on 
         [CyberChef](https://gchq.github.io/CyberChef/) and click save. Select "clean JSON" and copy the output.
@@ -219,7 +227,8 @@ components:
       type: object
       properties:
         input: 
-          type: string
+          type: array
+          items: string
           example: "input for recipe"
         recipe:
           type: array


### PR DESCRIPTION
Current API only permits one Bake per request which is inefficient for bulk workloads. Batch Backing endpoint allows execution of recipe against multiple inputs in a single request