### PR TITLE
feat: build & push docker image to ghcr.io

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,3 +54,45 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
+  publish-github:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+      - uses: docker/setup-buildx-action@v3
+        id: buildx
+        with:
+          version: latest
+          install: true
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: metadata
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.0.') }}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+      - uses: docker/build-push-action@v6
+        id: build
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: ${{ env.PLATFORMS }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Hello!

Thanks for your work on this repository - it is really helpful for me!

It would be awesome if you could push a built image to a container registry (preferably `ghcr.io`). This PR implements this process based on the official GitHub actions from the Docker guys. The image can be found at `ghcr.io/gchq/cyberchef-server:vX.Y.Z`.

Thanks in advance.